### PR TITLE
WIP: play the schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ## Project setup
 ```
 npm ci
+
+# If using NPM >= 6
+npm install --legacy-peer-deps
 ```
 
 ### Compiles and hot-reloads for development

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,7 @@
 						points="14.43,10 12,2 9.57,10 2,10 8.18,14.41 5.83,22 12,17.31 18.18,22 15.83,14.41 22,10"
 					)
 				template {{ favs.length }}
+			bunt-button(@click="toggleAudioPlayer") {{ audioPlayer ? 'Stop' : 'Play' }}
 			template(v-if="!inEventTimezone")
 				bunt-select(name="timezone", :options="[{id: schedule.timezone, label: schedule.timezone}, {id: userTimezone, label: userTimezone}]", v-model="currentTimezone", @blur="saveTimezone")
 			template(v-else)
@@ -55,6 +56,7 @@ import Buntpapier from 'buntpapier'
 import moment from 'moment-timezone'
 import LinearSchedule from 'components/LinearSchedule'
 import GridSchedule from 'components/GridSchedule'
+import { SchedulePlayer } from './audio'
 import { findScrollParent, getLocalizedString } from 'utils'
 
 Vue.use(Buntpapier)
@@ -92,7 +94,8 @@ export default {
 			showFilterModal: false,
 			favs: [],
 			allTracks: [],
-			onlyFavs: false
+			onlyFavs: false,
+			audioPlayer: null
 		}
 	},
 	computed: {
@@ -271,6 +274,16 @@ export default {
 		},
 		resetFilteredTracks () {
 			this.allTracks.forEach(t => t.selected = false)
+		},
+		toggleAudioPlayer () {
+			// TODO: pass in the schedule?
+			if (this.audioPlayer) {
+				this.audioPlayer.stop()
+				this.audioPlayer = null
+			} else {
+				this.audioPlayer = new SchedulePlayer()
+				this.audioPlayer.start()
+			}
 		}
 	}
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,134 @@
+// Ripped from:
+// https://brandnewbox.com/inthestacks/
+
+const notes = {
+	C: 261.63,
+	Db: 277.18,
+	D: 293.66,
+	Eb: 311.13,
+	E: 329.63,
+	F: 349.23,
+	Gb: 369.99,
+	G: 392.00,
+	Ab: 415.30,
+	A: 440,
+	Bb: 466.16,
+	B: 493.88,
+	// C: 523.25
+}
+
+const config = {
+	tempo: 140,
+	gain: 0.5,
+	waveform: 'sine',
+
+	note: {
+		attack: 0.3,
+		sustain: 0.8,
+		release: 0.3,
+		length: 0.2,
+	},
+
+	vibrato: {
+		speed: 10,
+		amount: 0
+	},
+
+	delayTime: 0.65,
+	delayAmount: 0.05,
+	feedback: 0.05
+}
+
+export class SchedulePlayer {
+	constructor (schedule) {
+		this.notes = []
+		this.timerId = setInterval(
+			() => this.tick(),
+			60 / config.tempo * 1000
+		)
+		this.ctx = new AudioContext()
+
+		this.master = this.ctx.createGain()
+		this.master.connect(this.ctx.destination)
+		this.master.gain.value = config.gain
+
+		this.delay = this.ctx.createDelay()
+		this.feedback = this.ctx.createGain()
+		this.delayAmount = this.ctx.createGain()
+
+		this.delayAmount.connect(this.delay)
+		this.delay.connect(this.feedback)
+		this.feedback.connect(this.delay)
+		this.delay.connect(this.master)
+
+		this.delay.delayTime.value = config.delayTime
+		this.delayAmount.gain.value = config.delayAmount
+		this.feedback.gain.value = config.feedback
+
+		this.currentNote = 0
+
+		this.setSchedule(schedule)
+	}
+
+	setSchedule (schedule) {
+		this.notes = [
+			notes.C,
+			notes.C,
+			notes.D,
+			notes.G,
+		]
+	}
+
+	start () {
+		console.debug('SchedulePlayer: start')
+	}
+
+	tick () {
+		console.log('tock')
+
+		if (this.notes.length === 0) return
+
+		this.currentNote = (this.currentNote + 1) % this.notes.length
+		this.playNote(this.notes[this.currentNote])
+	}
+
+	stop () {
+		console.debug('SchedulePlayer: stop')
+		if (this.timerId) clearInterval(this.timerId)
+	}
+
+	/** @param {number} frequency */
+	playNote (frequency) {
+		console.debug('SchedulePlayer: play %d', frequency)
+
+		const { currentTime } = this.ctx
+		const { note, vibrato, waveform } = config
+
+		const osc = this.ctx.createOscillator()
+		const noteGain = this.ctx.createGain()
+
+		noteGain.gain.setValueAtTime(0, 0)
+		noteGain.gain.linearRampToValueAtTime(note.sustain, currentTime + note.length * note.attack)
+		noteGain.gain.setValueAtTime(note.sustain, currentTime + note.length - note.length * note.release)
+		noteGain.gain.linearRampToValueAtTime(0, currentTime + note.length)
+
+		const lfoGain = this.ctx.createGain()
+		lfoGain.gain.setValueAtTime(vibrato.amount, 0)
+		lfoGain.connect(osc.frequency)
+
+		const lfo = this.ctx.createOscillator()
+		lfo.frequency.setValueAtTime(vibrato.speed, 0)
+		lfo.start(0)
+		lfo.stop(currentTime + note.length)
+		lfo.connect(lfoGain)
+
+		osc.type = waveform
+		osc.frequency.setValueAtTime(frequency, 0)
+		osc.start(0)
+		osc.stop(currentTime + note.length)
+		osc.connect(noteGain)
+
+		noteGain.connect(this.master)
+		noteGain.connect(this.delay)
+	}
+}


### PR DESCRIPTION
I've somewhat jokingly added the groundwork to play the current schedule as audio, it should probably be behind a feature flag or special query parameter? It's very heavily based off of https://brandnewbox.com/inthestacks/ right now, the effects can be tweaked (although I don't know much about audio for this).

At this point I'd be interested in what algorithm you might think is appropriate to convert a schedule someone is working on into a series of notes to play.

**whats changed**

- There is a new "Play" / "Stop" button at the top of the schedule editor which toggles playing
- There is a new "audio.js" file which has `SchedulePlayer` in it which is responsible for taking a schedule (I'm not sure how yet) and playing it on loop until stopped
- I imagine `App.vue` would call `SchedulePlayer#setSchedule` when the schedule changes and it would change which notes it will play

I also added a note to the readme about developer setup on newer versions of NPM